### PR TITLE
feat: Add min_disk_size attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ version:          Version number (optional)
 ssh_user:         Default user in the image (optional, defaults to distribution)
 testing_enabled:  Enables extended testing (optional, defaults to True)
 display_name:     Override the generated image name (optional)
+min_disk_size:    Override the minimum disk size (optional, defaults to 10GB)
 # (more to come)
 ```
 

--- a/tasks/check_for_updates.yml
+++ b/tasks/check_for_updates.yml
@@ -51,6 +51,7 @@
     ssh_user: "{{ image_data.ssh_user | default(image_data.distribution) }}"
     testing_enabled: "{{ image_data.testing_enabled | default(true) }}"
     config_drive: "{{ image_data.config_drive | default(false) }}"
+    min_disk_size: "{{ image_data.min_disk_size | default(10) }}"
     display_name: >-
       {{
         image_data.display_name | default(

--- a/tasks/upload_image.yml
+++ b/tasks/upload_image.yml
@@ -12,6 +12,7 @@
     disk_format: qcow2
     state: present
     filename: "{{ tmp_folder }}/{{ filename }}"
+    min_disk: "{{ min_disk_size }}"
     properties:
       description: "{{ ansible_date_time.date }}"
       uploaded_by: Image Uploader


### PR DESCRIPTION
This sets a minimum disk size for every newly uploaded image in openstack. The default value is 10GB. Without this attribute users could create disks with less space than required by the image, producing cryptic errors.