### PR TITLE
Remove race condition on ssh startup with retries

### DIFF
--- a/tasks/testing.yml
+++ b/tasks/testing.yml
@@ -140,13 +140,11 @@
   block:
     - name: Test Echo on New Server
       ansible.builtin.command: "date"
+      retries: 10
+      delay: 3
+      register: result
+      until: result.rc == 0
       changed_when: false
-      register: echo_output
-
-    # Print the echo to command line
-    - name: Print Echo
-      ansible.builtin.debug:
-        var: echo_output
 
 ###################################################################################
 ###  Once tested, the instance and associated resources should then be removed ###


### PR DESCRIPTION
Sometimes the ubuntu boot process already opens the ssh port but is not ready for user traffic to it:
```
System is booting up.
Unprivileged users are not permitted to log in yet. Please come back later. For
technical details, see pam_nologin(8).
```

Retry the echo test a couple of times before giving up on it :)