### PR TITLE
Make QCOW information match broader to include qcow v3

### DIFF
--- a/tasks/download_image.yml
+++ b/tasks/download_image.yml
@@ -13,8 +13,8 @@
   register: file_information
   changed_when: false
 
-- name: File is a qcow2 image
-  when: '"QEMU QCOW2 Image" in file_information.stdout'
+- name: File is a qcow image
+  when: '"QEMU QCOW" in file_information.stdout'
   block:
     - name: Proceed to upload
       ansible.builtin.include_tasks:


### PR DESCRIPTION
The newest debian 12 minor release is a qcow v3 image format. It still has the file extension qcow2 but the `file_information.stdout` does not match anymore.

We make the match a bit more relaxed to match on all qcow versions.