### PR TITLE
Fix bug when multiple images have the same name

### DIFF
--- a/tasks/rotate_image.yml
+++ b/tasks/rotate_image.yml
@@ -1,6 +1,8 @@
 - name: Check for previous public image
   openstack.cloud.image_info:
     image: "{{ display_name }} - Latest"
+    properties:
+      uploaded_by: Image Uploader
   register: latest_image_in_glance
   changed_when: latest_image_in_glance.image
 


### PR DESCRIPTION
Users can upload images with any name. Only check privious images which were uploaded by the 'Image Uploader'